### PR TITLE
session ctor takes object as argument for passing in more settings

### DIFF
--- a/lib/Session.js
+++ b/lib/Session.js
@@ -60,7 +60,7 @@ const minimumMessageId = 60
 
 class Session extends EventEmitter {
 
-  constructor (port) {
+  constructor ({port}) {
     super()
     this.session = new Libtorrent.Session(port)
     this.plugin = new JoyStreamAddon.Plugin(minimumMessageId)


### PR DESCRIPTION
Our electron app passes an object as argument when constructing a session.
This is a good approach if we find we need to pass in more settings/options