### PR TITLE
locate nan headers in flat node_modules folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 include_directories(${CMAKE_JS_INC})
 
+# cmake-js cannot find the nan headers when our package is installed
+# in parallel to it. This happens when pacakge is being installed as
+# a dependency as opposed to just running npm install inside the package
 include_directories("../nan/")
 
 file(GLOB_RECURSE JOYSTREAM_SOURCE_FILES "src/*.cpp")


### PR DESCRIPTION
cmake-js doesn't seem to be able to correctly locate nan headers when our addon is installed as a dependency and into this folder structure:
```
app/
  package.json
  node_modules/
    nan/
    cmake-js/
    joystream-node/
```

So far we have seen this issue when try to install the module from local folder and I suspect this will be the case also when the module is published on npm or we try to install it via the git repo as well.

This fix is simply adding a relative path to nan headers in the CMakeLists.txt