### PR TITLE
add dev dependencies unzip, pullstream, slice-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,13 @@
     "babel-eslint": "^7.1.1",
     "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-preset-es2015-node": "^6.1.1",
-    "mocha": "^2.2.5",
-    "electron-mocha": "^3.3.0",
     "chai": "^3.5.0",
-    "sinon": "^2.1.0"
+    "electron-mocha": "^3.3.0",
+    "mocha": "^2.2.5",
+    "pullstream": "^1.0.0",
+    "sinon": "^2.1.0",
+    "slice-stream": "^1.0.0",
+    "unzip": "^0.1.11"
   },
   "standard": {
     "parser": "babel-eslint"


### PR DESCRIPTION
these seem to be required when the module is npm linked in an electron app and electron-forge tries to rebuild