### PR TITLE
Emit event on peer plugin status updated

### DIFF
--- a/lib/Torrent.js
+++ b/lib/Torrent.js
@@ -99,6 +99,7 @@ class Torrent extends EventEmitter {
     var peer = this.peers.get(status.endPoint.address + ':' + status.endPoint.key)
     if (peer) {
       peer._onPeerPluginStatusUpdate(status)
+      this.emit('peerPluginStatusUpdateAlert', status)
     }
   }
 


### PR DESCRIPTION
Added an event so torrent can re-compute value when new peers are updated.