### PR TITLE
add start/stop processing alerts methods to session

### DIFF
--- a/lib/Session.js
+++ b/lib/Session.js
@@ -18,7 +18,7 @@ const statusUpdateInterval = 1000
 
 class Session extends EventEmitter {
 
-  constructor ({port}) {
+  constructor ({port, autoStartProcessing = true}) {
     super()
     this.session = new Libtorrent.Session(port)
     this.plugin = new JoyStreamAddon.Plugin(minimumMessageId)
@@ -28,8 +28,8 @@ class Session extends EventEmitter {
       // Add plugin to session
     this.session.addExtension(this.plugin)
 
-    // Start processing automatically? or allow application to start when ready
-    this.startProcessingAlerts()
+    if (autoStartProcessing)
+      this.startProcessingAlerts()
   }
 
   startProcessingAlerts (milliseconds = statusUpdateInterval) {

--- a/lib/Session.js
+++ b/lib/Session.js
@@ -28,29 +28,41 @@ class Session extends EventEmitter {
       // Add plugin to session
     this.session.addExtension(this.plugin)
 
-    setInterval(() => {
-      // Pop alerts
-      var alerts = this.session.popAlerts()
-
-      // Process alerts
-      for (var i in alerts) {
-        this.process(alerts[i])
-      }
-
-      // Request plugin and peer status updates
-      for (var [infoHash] of this.torrents.entries()) {
-        this.plugin.post_torrent_plugin_status_updates(infoHash)
-        this.plugin.post_peer_plugin_status_updates(infoHash)
-      }
-    }, statusUpdateInterval)
-
+    // Start processing automatically? or allow application to start when ready
+    this.startProcessingAlerts()
   }
 
-    /* * * * * * * * * * * * *
-     *
-     *  Session methods
-     *
-     * * * * * * * * * * * * */
+  startProcessingAlerts (milliseconds = statusUpdateInterval) {
+    if (this._timer) return
+    this._timer = setInterval(() => this._processAlerts(), milliseconds)
+  }
+
+  stopProcessingAlerts () {
+    if (this._timer) {
+      clearInterval(this._timer)
+      this._timer = null
+    }
+  }
+
+  /**
+   * Process alerts and post peer and torrent plugin updates
+   * called internally by timer
+   */
+  _processAlerts () {
+    // Pop alerts
+    var alerts = this.session.popAlerts()
+
+    // Process alerts
+    for (var i in alerts) {
+      this.process(alerts[i])
+    }
+
+    // Request plugin and peer status updates
+    for (var [infoHash] of this.torrents.entries()) {
+      this.plugin.post_torrent_plugin_status_updates(infoHash)
+      this.plugin.post_peer_plugin_status_updates(infoHash)
+    }
+  }
 
  /**
   * Get the port libtorrent is using.

--- a/lib/Session.js
+++ b/lib/Session.js
@@ -8,7 +8,7 @@ const Torrent = require('./Torrent')
 const assert = require('assert')
 
 const minimumMessageId = 60
-const statusUpdateInterval = 1000
+const statusUpdateInterval = 150
 
 /*
  * Class Node


### PR DESCRIPTION
Currently there is no way to clear the timer created to process alerts, which should be done while gracefully shutting down an app.

This PR adds two methods to start and stop the timer. The timer is started automatically when the the session is constructed, unless the `autoStartProcessing` option is set to false.