### PR TITLE
add binding for DropPeer request

### DIFF
--- a/lib/Torrent.js
+++ b/lib/Torrent.js
@@ -143,6 +143,10 @@ class Torrent extends EventEmitter {
     this.handle.connectPeer(peer)
   }
 
+  dropPeer (peerId, callback = () => {}) {
+    this.plugin.dropPeer(this.infoHash, peerId, callback)
+  }
+
 }
 
 module.exports = Torrent

--- a/src/Plugin.cpp
+++ b/src/Plugin.cpp
@@ -87,6 +87,7 @@ NAN_MODULE_INIT(Plugin::Init) {
   Nan::SetPrototypeMethod(tpl, "start_downloading", StartDownloading);
   Nan::SetPrototypeMethod(tpl, "start_uploading", StartUploading);
   Nan::SetPrototypeMethod(tpl, "set_libtorrent_interaction", SetLibtorrentInteraction);
+  Nan::SetPrototypeMethod(tpl, "dropPeer", DropPeer);
 
   constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
   Nan::Set(target, Nan::New("Plugin").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
@@ -430,6 +431,26 @@ NAN_METHOD(Plugin::SetLibtorrentInteraction) {
     joystream::extension::request::SetLibtorrentInteraction request(infoHash,
                                                                     libtorrentInteraction,
                                                                     detail::subroutine_handler::CreateGenericHandler(managedCallback));
+
+    // Submit request
+    plugin->_plugin->submit(request);
+
+    RETURN_VOID
+}
+
+
+NAN_METHOD(Plugin::DropPeer) {
+
+    // Get validated parameters
+    GET_THIS_PLUGIN(plugin)
+    ARGUMENTS_REQUIRE_DECODED(0, infoHash, libtorrent::sha1_hash, libtorrent::node::sha1_hash::decode)
+    ARGUMENTS_REQUIRE_DECODED(1, peerId, libtorrent::peer_id, libtorrent::node::peer_id::decode)
+    ARGUMENTS_REQUIRE_CALLBACK(2, managedCallback)
+
+    // Create request
+    joystream::extension::request::DropPeer request(infoHash,
+                                                    peerId,
+                                                    detail::subroutine_handler::CreateGenericHandler(managedCallback));
 
     // Submit request
     plugin->_plugin->submit(request);

--- a/src/Plugin.hpp
+++ b/src/Plugin.hpp
@@ -57,6 +57,7 @@ private:
   static NAN_METHOD(StartDownloading);
   static NAN_METHOD(StartUploading);
   static NAN_METHOD(SetLibtorrentInteraction);
+  static NAN_METHOD(DropPeer);
 
 };
 


### PR DESCRIPTION
Bindings for `DropPeer` request added in https://github.com/JoyStream/extension-cpp/pull/19

Note: expect Travis build to fail, until we merge extension-cpp into master