### PR TITLE
emit separate error event for save_resume_data_failed_alert

### DIFF
--- a/lib/Session.js
+++ b/lib/Session.js
@@ -530,7 +530,7 @@ class Session extends EventEmitter {
     alertDebug(infoHash)
 
     if (torrent) {
-      torrent._onResumeDataFailed()
+      torrent._onResumeDataFailed(alert.error)
     }
   }
 

--- a/lib/Torrent.js
+++ b/lib/Torrent.js
@@ -45,8 +45,8 @@ class Torrent extends EventEmitter {
     this.emit('resumedata', buff)
   }
 
-  _onResumeDataFailed () {
-    this.emit('error', new Error('resume data generation failed'))
+  _onResumeDataFailed (err) {
+    this.emit('resumedata_error', err)
   }
 
   _onMetaData (torrentInfo) {


### PR DESCRIPTION
Solves https://github.com/JoyStream/joystream-node/issues/57

Depends on https://github.com/JoyStream/libtorrent-node/pull/31