### PR TITLE
revert to OpenSSL v1.0.2j

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class JoyStreamNode(ConanFile):
                 "ProtocolSession/0.1.1@joystream/stable",
                 "Extension/0.1.1@joystream/stable",
                 "Boost/1.60.0@lasote/stable",
-                "OpenSSL/1.0.2k@lasote/stable")
+                "OpenSSL/1.0.2j@lasote/stable")
 
     generators = "cmake"
 


### PR DESCRIPTION
Reverting because Travis build is taking too long and failing when it tries to build openssl:

```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
```