### PR TITLE
update dependency to LibtorrentNode/0.0.3

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile
 class JoyStreamNode(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     requires = ("Libtorrent/1.1.1@joystream/stable",
-                "LibtorrentNode/0.0.2@joystream/stable",
+                "LibtorrentNode/0.0.3@joystream/stable",
                 "CoinCore/0.1.1@joystream/stable",
                 "Common/0.1.1@joystream/stable",
                 "PaymentChannel/0.1.1@joystream/stable",


### PR DESCRIPTION
I prepared a release: https://github.com/JoyStream/libtorrent-node/releases/tag/v0.0.3
and published the recipe for v0.0.3 to the joystream conan server