### PR TITLE
session: guard against processing alerts of removed torrents

### DIFF
--- a/lib/Session.js
+++ b/lib/Session.js
@@ -10,6 +10,10 @@ const assert = require('assert')
 const minimumMessageId = 60
 const statusUpdateInterval = 400
 
+function isEmptyInfoHash (infoHash) {
+  return infoHash === '0000000000000000000000000000000000000000' // 20-bytes (160-bit) all zeros info_hash
+}
+
 /*
  * Class Node
  * Manage the alerts and execute the differents request (add_torrent, buy_torrent,...)
@@ -379,15 +383,18 @@ class Session extends EventEmitter {
     var alertDebug = debug('session:metadataReceivedAlert')
     var torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
 
+    var torrent = this.torrents.get(infoHash)
+
     var torrentInfo = torrentHandle.torrentFile()
-    var torrent = this.torrents.get(torrentHandle.infoHash())
 
     if (torrentInfo && torrent) {
-      alertDebug(torrentHandle.infoHash())
+      alertDebug(infoHash)
       torrent._onMetaData(torrentInfo)
     }
   }
@@ -397,11 +404,11 @@ class Session extends EventEmitter {
     var alertDebug = debug('session:metadataFailedAlert')
     var torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
-      return
-    }
+    const infoHash = torrentHandle.infoHash()
 
-    alertDebug(torrentHandle.infoHash())
+
+
+    alertDebug(infoHash)
   }
 
   _addTorrentAlert (alert) {
@@ -414,11 +421,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     // if a torrent is added without flag_duplicate_is_error in add torrent parameters
     // we may get an add_torrent_alert for an existing torrent
@@ -448,11 +455,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       alertDebug(infoHash)
@@ -475,11 +482,11 @@ class Session extends EventEmitter {
   _stateChangedAlert (alert) {
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = alert.handle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -513,11 +520,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       alertDebug(infoHash)
@@ -531,11 +538,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     alertDebug(infoHash)
 
@@ -550,11 +557,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     alertDebug(infoHash)
 
@@ -569,11 +576,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -584,11 +591,11 @@ class Session extends EventEmitter {
   _torrentCheckedAlert (alert) {
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -611,11 +618,11 @@ class Session extends EventEmitter {
   _readPieceAlert (alert) {
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -635,11 +642,11 @@ class Session extends EventEmitter {
   _pieceFinishedAlert (alert) {
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -663,11 +670,11 @@ class Session extends EventEmitter {
   _peerPluginStatusUpdateAlert (alert) {
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -680,11 +687,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -697,11 +704,11 @@ class Session extends EventEmitter {
 
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)
@@ -712,11 +719,11 @@ class Session extends EventEmitter {
   __emitEventOnValidTorrent (eventName, alert) {
     const torrentHandle = alert.handle
 
-    if (!torrentHandle.isValid()) {
+    const infoHash = torrentHandle.infoHash()
+
+    if (isEmptyInfoHash(infoHash)) {
       return
     }
-
-    const infoHash = torrentHandle.infoHash()
 
     if (this.torrents.has(infoHash)) {
       const torrent = this.torrents.get(infoHash)


### PR DESCRIPTION
Before processing every torrent alert we make sure the torrent handle is valid, to handle case where torrent has been removed and the alerts are not yet processed.