### PR TITLE
Modify the updateStatusInterval from 400 to 100 ms

### DIFF
--- a/lib/Session.js
+++ b/lib/Session.js
@@ -8,7 +8,7 @@ const Torrent = require('./Torrent')
 const assert = require('assert')
 
 const minimumMessageId = 60
-const statusUpdateInterval = 400
+const statusUpdateInterval = 100
 
 function isEmptyInfoHash (infoHash) {
   return infoHash === '0000000000000000000000000000000000000000' // 20-bytes (160-bit) all zeros info_hash


### PR DESCRIPTION
It will make the streaming a little bit faster. For now the 400ms is adding an artificial latency and we need to wait almost 4sec in order to have a media start playing.