### PR TITLE
Assisted peer discovery

### DIFF
--- a/lib/Session.js
+++ b/lib/Session.js
@@ -549,9 +549,10 @@ class Session extends EventEmitter {
     alertDebug(infoHash)
 
     if (this.torrents.has(infoHash)) {
-      this.torrents.delete(infoHash)
+      const secondaryInfoHash = this.torrents.get(infoHash).secondaryInfoHash
+      this.torrentsBySecondaryHash.delete(secondaryInfoHash)
 
-      // TODO remove from torrentsBySecondaryHash map?
+      this.torrents.delete(infoHash)
 
       this.emit('torrent_removed', infoHash)
     }


### PR DESCRIPTION
A few improvements and bug fixes over #85 

- [x] Adjusted announcement interval to be more frequent (2 minutes), (down from 15 minutes)
- [x] Separate intervals for announcement and getting peers
- [x] Get peers when torrent is added
- [x] Fix call to announce on torrent added which was announcing wrong port `undefined`
